### PR TITLE
#25_isbn 존재여부에 따라 분리해서 처리

### DIFF
--- a/src/main/java/com/cowlib/controller/BookMetaController.java
+++ b/src/main/java/com/cowlib/controller/BookMetaController.java
@@ -1,15 +1,16 @@
 package com.cowlib.controller;
 
-import java.util.List;
-
+import com.cowlib.client.DaumBookClient;
+import com.cowlib.model.BookMeta;
+import com.cowlib.repository.BookMetaRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import com.cowlib.client.DaumBookClient;
-import com.cowlib.model.BookMeta;
-import com.cowlib.repository.BookMetaRepository;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @RestController
@@ -24,18 +25,29 @@ public class BookMetaController {
 
     @GetMapping
     public List<BookMeta> search(@RequestParam(value = "q") String q) {
-        List<BookMeta> bookMetas = client.search(q);
-
-        for (BookMeta bookMeta : bookMetas) {
-            BookMeta alreaySaved = bookMetaRepository.select(bookMeta);
-
-            if (alreaySaved == null) {
-                bookMetaRepository.insert(bookMeta);
-            }else {
-                bookMeta = alreaySaved;
+        List<BookMeta> searched = client.search(q);
+        List<BookMeta> saved = new ArrayList<>();
+        for (BookMeta bookMeta : searched) {
+            if(bookMeta.isEmptyIsbns()){
+                continue;
             }
+            BookMeta alreadySaved = findBookMeta(bookMeta);
 
+            if (alreadySaved != null) {
+                saved.add(alreadySaved);
+            } else {
+                bookMetaRepository.insert(bookMeta);
+                saved.add(bookMeta);
+            }
         }
-        return bookMetas;
+        return saved;
+    }
+
+    private BookMeta findBookMeta(BookMeta bookMeta) {
+        if(bookMeta.isEmptyIsbn13()){
+            return bookMetaRepository.selectByIsbn(bookMeta);
+        } else {
+            return bookMetaRepository.selectByIsbn13(bookMeta);
+        }
     }
 }

--- a/src/main/java/com/cowlib/controller/CallNumberController.java
+++ b/src/main/java/com/cowlib/controller/CallNumberController.java
@@ -18,4 +18,11 @@ public class CallNumberController {
         return callNumber;
     }
 
+    @DeleteMapping
+    public CallNumber delete(CallNumber callNumber) {
+        callNumber.setDeleted(true);
+        callNumberRepository.update(callNumber);
+        return callNumber;
+    }
+
 }

--- a/src/main/java/com/cowlib/model/BookMeta.java
+++ b/src/main/java/com/cowlib/model/BookMeta.java
@@ -1,6 +1,7 @@
 package com.cowlib.model;
 
 import lombok.Data;
+import org.springframework.util.StringUtils;
 
 @Data
 public class BookMeta {
@@ -12,4 +13,12 @@ public class BookMeta {
     private String description;
     private String publisher;
     private String coverUrl;
+
+    public boolean isEmptyIsbns() {
+        return StringUtils.isEmpty(isbn) && StringUtils.isEmpty(isbn13);
+    }
+
+    public boolean isEmptyIsbn13() {
+        return StringUtils.isEmpty(isbn13);
+    }
 }

--- a/src/main/java/com/cowlib/repository/BookMetaRepository.java
+++ b/src/main/java/com/cowlib/repository/BookMetaRepository.java
@@ -17,4 +17,10 @@ public interface BookMetaRepository {
 
     @Select("select * from book_meta where id=#{id}")
     BookMeta selectById(int id);
+
+    @Select("select * from book_meta where isbn=#{isbn}")
+    BookMeta selectByIsbn(BookMeta bookMeta);
+
+    @Select("select * from book_meta where isbn13=#{isbn13}")
+    BookMeta selectByIsbn13(BookMeta bookMeta);
 }

--- a/src/main/java/com/cowlib/repository/CallNumberRepository.java
+++ b/src/main/java/com/cowlib/repository/CallNumberRepository.java
@@ -16,6 +16,9 @@ public interface CallNumberRepository {
     @Delete("delete from call_number where id=#{id}")
     void delete(CallNumber callNumber);
 
-    @Select("select * from call_number where owner_id=#{ownerId}")
+    @Select("select * from call_number where owner_id=#{ownerId} and is_deleted=false")
     List<CallNumber> selectByOwnerId(int ownerId);
+
+    @Update("update call_number set is_deleted=#{isDeleted} where id=#{id}")
+    void update(CallNumber callNumber);
 }


### PR DESCRIPTION
bookmeta_id가 없는 이유를 추적해봤더니, DB에 있던 데이터 중에 isbn 과 isbn13이 둘 다 없는 책이 있었다.
or 조건으로 같은게 없으면 새 bookmeta를 추가하고 있어서 isbn 하나만 없는 책은 위와 같은 에러가 나고 있었던 것.

isbn 등록되지 않은 책은 일단 지원 안 하기로 하고( 추후에 논의해 보아야 함)
isbn이 없는 책은 DB에 추가하지 않기로 함